### PR TITLE
Remove space in time punctuation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
 
         Ok((files_renamed, time_elapsed)) => {
             println!(
-                "{} files renamed in {} s. See you next time!\n(^ _ ^)/",
+                "{} files renamed in {}s. See you next time!\n(^ _ ^)/",
                 files_renamed, time_elapsed
             );
         }


### PR DESCRIPTION
Following commands such as unix's `time` in removing space between value and unit. (This thing is fast.)

![image](https://user-images.githubusercontent.com/46059092/90819217-37ed2080-e31f-11ea-9f25-7937d76caabe.png)
